### PR TITLE
Update asciidoctor.vim

### DIFF
--- a/ftplugin/asciidoctor.vim
+++ b/ftplugin/asciidoctor.vim
@@ -119,6 +119,10 @@ endif
 if has("folding") && get(g:, 'asciidoctor_folding', 0)
     function! AsciidoctorFold() "{{{
         let line = getline(v:lnum)
+        
+        if (v:lnum == 1) && (line =~ '^----*$')                            
+           return ">1"                                                     
+        endif             
 
         " Regular headers
         let depth = match(line, '\(^=\+\)\@<=\( .*$\)\@=')


### PR DESCRIPTION
asciidoctor files are now used a lot with yaml front-matter.   there is a skip-front-matter attribute available for that in asciidoctor.   seems appropriate that where a front matter header exists it is foldable.   Hope this is ok.   Appreciate the plugin!